### PR TITLE
Update manifest.toml

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -72,7 +72,7 @@ volume-id = "main"
 
 [volumes.nextcloud]
 package-id = "nextcloud"
-path = "data/embassy/files"
+path = "/"
 readonly = true
 type = "pointer"
 volume-id = "nextcloud"


### PR DESCRIPTION
This fixes a bug where a nextcloud install / reinstall can be broken by the existence of any directories