### PR TITLE
Fix/nextcloud permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ FROM alpine:latest
 RUN echo https://dl-cdn.alpinelinux.org/alpine/edge/community >> /etc/apk/repositories
 RUN apk update
 RUN apk add bash curl nginx tini yq && \
-    addgroup -g 33 www-data && \
-    adduser nginx www-data
+    addgroup -g 33 nextcloud && \
+    addgroup nginx nextcloud
 
 ADD www /var/www
 RUN cp /var/www/assets/main.css /var/www/index/main.css

--- a/Makefile
+++ b/Makefile
@@ -30,5 +30,5 @@ docker-images/x86_64.tar: Dockerfile docker_entrypoint.sh
 	mkdir -p docker-images
 	DOCKER_CLI_EXPERIMENTAL=enabled docker buildx build --tag start9/$(PKG_ID)/main:$(PKG_VERSION) --platform=linux/amd64 -o type=docker,dest=docker-images/x86_64.tar .
 
-scripts/embassy.js: $(SCRIPTS_SRC)
-	deno bundle scripts/embassy.ts scripts/embassy.js
+scripts/embassy.js: $(TS_FILES)
+	deno run --allow-read --allow-write --allow-env --allow-net scripts/bundle.ts

--- a/scripts/bundle.ts
+++ b/scripts/bundle.ts
@@ -1,0 +1,6 @@
+// scripts/bundle.ts
+import { bundle } from "https://deno.land/x/emit@0.40.0/mod.ts";
+
+const result = await bundle("scripts/embassy.ts");
+
+await Deno.writeTextFile("scripts/embassy.js", result.code);


### PR DESCRIPTION
  Title: Fix Dockerfile build error and nginx Nextcloud permissions                                                                                                                
                                                                                                                                                                                   
  ## Summary                                                                                                                                                                       
  - **Fix GID mismatch causing 403 on Nextcloud files:** Alpine's `www-data` group                                                                                                 
    has GID 82, but Nextcloud (Debian-based) owns data files with GID 33. The previous
    fix (3b44cb9) tried to create a `www-data` group with GID 33, which failed because                                                                                             
    the name was already taken. Now creates a `nextcloud` group at GID 33 and adds the                                                                                             
    nginx user to it, giving workers the correct group access.
  - **Fix CI build failure from deprecated `deno bundle`:** `deno bundle` was removed
    in Deno 2.x. Replaced with a `bundle.ts` script using `deno.land/x/emit`, matching
    the pattern used in other StartOS packages. Also fixed undefined `$(SCRIPTS_SRC)`
    Makefile variable to `$(TS_FILES)`.

  ## Test plan
  - [x] `make` completes successfully (Docker build no longer fails on `addgroup`)
  - [x] CI build passes (no more `deno bundle` error)
  - [x] Configure a subdomain to serve from Nextcloud and verify no 403 Forbidden
  - [x] Verify File Browser source still works (regression check)