### PR TITLE
fix: increase nginx server_names_hash limits for large site counts

### DIFF
--- a/startos/main.ts
+++ b/startos/main.ts
@@ -141,7 +141,8 @@ http {
     keepalive_timeout 65;
     keepalive_requests 10000;
     types_hash_max_size 4096;
-    server_names_hash_bucket_size 128;
+    server_names_hash_max_size 2048;
+    server_names_hash_bucket_size 256;
 
     access_log  /var/log/nginx/access.log  main;
 

--- a/startos/versions/index.ts
+++ b/startos/versions/index.ts
@@ -1,7 +1,7 @@
-import { VersionGraph } from '@start9labs/start-sdk'
-import { v_1_0_0_2 } from './v1.0.0.2'
-
+import { VersionGraph } from "@start9labs/start-sdk"
+import { v_1_0_0_2 } from "./v1.0.0.2"
+import { v_1_0_0_3 } from "./v1.0.0.3"
 export const versionGraph = VersionGraph.of({
-  current: v_1_0_0_2,
-  other: [],
+  current: v_1_0_0_3,
+  other: [v_1_0_0_2],
 })

--- a/startos/versions/v1.0.0.3.ts
+++ b/startos/versions/v1.0.0.3.ts
@@ -1,0 +1,9 @@
+import { VersionInfo, IMPOSSIBLE } from "@start9labs/start-sdk"
+export const v_1_0_0_3 = VersionInfo.of({
+  version: "1.0.0:3",
+  releaseNotes: { en_US: "Increased nginx server_names_hash limits to support large numbers of hosted sites" },
+  migrations: {
+    up: async ({ effects }) => {},
+    down: IMPOSSIBLE,
+  },
+})


### PR DESCRIPTION
**Fix: increase nginx server_names_hash limits for large site counts**

Users running 50+ sites were seeing nginx warnings:
```
could not build optimal server_names_hash, you should increase either
server_names_hash_max_size: 512 or server_names_hash_bucket_size: 128
```
This caused sites to stop loading entirely.

**Changes:**
- `server_names_hash_max_size` increased from default 512 → 2048
- `server_names_hash_bucket_size` increased from 128 → 256

Both values are in the nginx config template in `startos/main.ts`. Version bumped to `1.0.0:3`.