### PR TITLE
fix: increase nginx server_names_hash limits for large site counts

### DIFF
--- a/startos/main.ts
+++ b/startos/main.ts
@@ -141,7 +141,8 @@ http {
     keepalive_timeout 65;
     keepalive_requests 10000;
     types_hash_max_size 4096;
-    server_names_hash_bucket_size 128;
+    server_names_hash_max_size 2048;
+    server_names_hash_bucket_size 256;
 
     access_log  /var/log/nginx/access.log  main;
 


### PR DESCRIPTION
**Fix: increase nginx server_names_hash limits for large site counts**

Users running 50+ sites were seeing nginx warnings:
```
could not build optimal server_names_hash, you should increase either
server_names_hash_max_size: 512 or server_names_hash_bucket_size: 128
```
This caused sites to stop loading entirely.

**Changes:**
- `server_names_hash_max_size` increased from default 512 → 2048
- `server_names_hash_bucket_size` increased from 128 → 256
