### PR TITLE
feat: serve a site's own 404.html when present

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Add, edit, and remove static websites.
 | **Inputs** | List of websites, each with: Name (text, required), Source (union: Filebrowser or Nextcloud), Folder Location (text, required), User (text, Nextcloud only, default: "admin"), Allow CORS (toggle, default off). Port is hidden/auto-assigned. |
 | **Outputs** | Website list saved to `store.json`; the nginx daemon reconciles (restarts) to apply the regenerated config |
 
-Websites are served if they contain `index.html` or `index.htm`. Directory listing is enabled for folders without either.
+Websites are served if they contain `index.html` or `index.htm`. Directory listing is enabled for folders without either. A site may ship its own `404.html`, which is served (with a 404 status) for any path that doesn't resolve; sites without one get nginx's stock 404 page.
 
 Enabling **Allow CORS** on a website adds `Access-Control-Allow-Origin: *` (plus `Access-Control-Allow-Methods` and `Access-Control-Allow-Headers`) to every response from that site. This makes the page reachable from cross-origin browser fetches — useful for protocols like Nostr NIP-05 that require fetching `/.well-known/nostr.json` from arbitrary clients. Leave it off unless you need it.
 

--- a/instructions.md
+++ b/instructions.md
@@ -27,6 +27,8 @@ After install, Start9 Pages posts a critical task — **Add your first website!*
 
 If the folder contains `index.html` or `index.htm`, that file is served at the root. Folders without one are served as a browsable directory listing.
 
+If the folder contains `404.html`, that page is served whenever a visitor requests a path that doesn't exist. Sites without one fall back to nginx's stock 404 page.
+
 You can host as many sites as you want by repeating the **Add** flow.
 
 ## Using Start9 Pages

--- a/startos/main.ts
+++ b/startos/main.ts
@@ -96,6 +96,7 @@ export const main = sdk.setupMain(async ({ effects }) => {
     absolute_redirect off;
     root ${root};
     index index.html index.htm;${corsHeaders}
+    error_page 404 /404.html;
     location / {
         try_files $uri $uri/ =404;
         autoindex on;

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -3,15 +3,16 @@ import { VersionInfo, IMPOSSIBLE } from '@start9labs/start-sdk'
 export const current = VersionInfo.of({
   version: '1.0.0:12',
   releaseNotes: {
-    en_US: 'Fixed broken redirects for directory URLs without a trailing slash',
+    en_US:
+      'Fixed broken redirects for directory URLs without a trailing slash. Websites can now provide their own 404.html error page.',
     es_ES:
-      'Corregidas las redirecciones rotas para URLs de directorio sin barra final',
+      'Corregidas las redirecciones rotas para URLs de directorio sin barra final. Los sitios web ahora pueden proporcionar su propia página de error 404.html.',
     de_DE:
-      'Fehlerhafte Weiterleitungen für Verzeichnis-URLs ohne abschließenden Schrägstrich behoben',
+      'Fehlerhafte Weiterleitungen für Verzeichnis-URLs ohne abschließenden Schrägstrich behoben. Websites können jetzt ihre eigene 404.html-Fehlerseite bereitstellen.',
     pl_PL:
-      'Naprawiono nieprawidłowe przekierowania adresów URL katalogów bez ukośnika na końcu',
+      'Naprawiono nieprawidłowe przekierowania adresów URL katalogów bez ukośnika na końcu. Strony internetowe mogą teraz udostępniać własną stronę błędu 404.html.',
     fr_FR:
-      'Correction des redirections défectueuses pour les URL de répertoire sans barre oblique finale',
+      "Correction des redirections défectueuses pour les URL de répertoire sans barre oblique finale. Les sites web peuvent désormais fournir leur propre page d'erreur 404.html.",
   },
   migrations: {
     up: async ({ effects }) => {},


### PR DESCRIPTION
## Summary

Adds `error_page 404 /404.html;` to the per-site nginx server block, so a website can ship its own not-found page instead of nginx's stock one. This is the second of the two follow-ups @nachorito flagged in #47; the `try_files $uri.html` one is tracked in #48.

## Behavior

Opt-in per site, with no new configuration surface:

| site contents | `GET /does-not-exist` |
| --- | --- |
| includes `404.html` | `404` + the site's own page |
| no `404.html` | `404` + nginx's stock page (unchanged) |

The status stays `404` — this is `error_page 404 /404.html;`, not `error_page 404 =200 …`, so it doesn't mask the error from crawlers or clients.

The missing-`404.html` case is a safe fallback rather than a redirect loop because `recursive_error_pages` defaults to `off`: nginx follows one `error_page` redirect, and when that target also misses it returns the built-in page.

## Version

No version bump. `1.0.0:12` exists only on alpha — beta, the reference registry, is still on `1.0.0:11` — so `:12`'s release notes are amended in place to cover this alongside the redirect fix rather than claiming a new revision.
